### PR TITLE
Process HtmlEntities

### DIFF
--- a/src/QuestPDF.Markdown/MarkdownRenderer.cs
+++ b/src/QuestPDF.Markdown/MarkdownRenderer.cs
@@ -330,6 +330,9 @@ internal sealed class MarkdownRenderer : IComponent
                     .BackgroundColor(_options.CodeInlineBackground)
                     .FontFamily(_options.CodeFont);
                 break;
+            case HtmlEntityInline htmlEntity:
+                text.Span(htmlEntity.Transcoded.ToString());
+                break;
             default:
                 text.Span($"Unknown LeafInline: {inline.GetType()}").BackgroundColor(Colors.Orange.Medium);
                 break;


### PR DESCRIPTION
I'm admittedly not a QuestPDF nor markdig expert, so there might be something I'm missing here. But I tested it with a simple unicode entity and it worked with no problems, so I thought I'd open a pull request in case you want to include it.