### PR TITLE
Changed from ConstantColumn to RelativeColumn with Fraction

### DIFF
--- a/src/QuestPDF.Markdown/MarkdownRenderer.cs
+++ b/src/QuestPDF.Markdown/MarkdownRenderer.cs
@@ -125,7 +125,9 @@ internal sealed class MarkdownRenderer : IComponent
                         if(result <= 1)
                         {
                             cd.RelativeColumn();
-                        }else{
+                        }
+                        else
+                        {
                             cd.RelativeColumn(fraction);
                         }                        
                     }

--- a/src/QuestPDF.Markdown/MarkdownRenderer.cs
+++ b/src/QuestPDF.Markdown/MarkdownRenderer.cs
@@ -125,8 +125,9 @@ internal sealed class MarkdownRenderer : IComponent
                         if(result <= 1)
                         {
                             cd.RelativeColumn();
-                        }
-                        cd.RelativeColumn(fraction);
+                        }else{
+                            cd.RelativeColumn(fraction);
+                        }                        
                     }
                     else
                     {

--- a/src/QuestPDF.Markdown/ParsedMarkdownDocument.cs
+++ b/src/QuestPDF.Markdown/ParsedMarkdownDocument.cs
@@ -52,6 +52,28 @@ public class ParsedMarkdownDocument
         var tasks = urls.Select([SuppressMessage("ReSharper", "AccessToDisposedClosure")] async (url) =>
         {
             if (url == null) return;
+
+            try
+            {
+                if(url.StartsWith("data:image"))
+                {
+                    // ![base64_image](data:image/png;base64,..{{base64 string}}..)
+                    var base64 = test.Split(",")[1];
+                    var data = Convert.FromBase64String(base64);
+                    using var skImage = SKImage.FromEncodedData(data);
+                    var pdfImage = Image.FromBinaryData(data);
+
+                    var image = new ImageWithDimensions(skImage.Width, skImage.Height, pdfImage);
+                    _imageCache.TryAdd(url, image);
+
+                    return;
+                }
+            }
+            finally
+            {
+                return;
+            }
+            
             
             await semaphore.WaitAsync().ConfigureAwait(false);
             

--- a/tests/QuestPDF.Markdown.Tests/test.md
+++ b/tests/QuestPDF.Markdown.Tests/test.md
@@ -424,6 +424,24 @@ Markdown | Less | Pretty
 | Pipe     | \|        |
 ```
 
+Headerless table using GridTables with variable column widths.
+
+_Won't render on GitHub, but will show in the PDF_
+
++------------------+--------------------------------------------------------------+
+| _A column spanning two columns._
++------------------+--------------------------------------------------------------+
+| **Small Column** | A much larger column that spans more of the available space. |
++------------------+--------------------------------------------------------------+
+
+```
++------------------+--------------------------------------------------------------+
+| _A column spanning two columns._
++------------------+--------------------------------------------------------------+
+| **Small Column** | A much larger column that spans more of the available space. |
++------------------+--------------------------------------------------------------+
+```
+
 ------
 
 # Blockquotes


### PR DESCRIPTION
Markdig col.Width is returning a percentage, this making the constant column that is expecting a point value very small column when rendered. This divides 100 into a fraction of 4 to calculate the relative column.